### PR TITLE
css: Fix selector to work on labels past the checked input

### DIFF
--- a/player.css
+++ b/player.css
@@ -128,8 +128,9 @@ body {
     max-height: 100%
 }
 
-.volume input~label:hover {
-    background: #ddd;
+.volume input~label:hover,
+.volume input:checked~label:hover {
+    background: #eee;
     cursor: pointer
 }
 


### PR DESCRIPTION
The colors were a bit off due to a missing selector